### PR TITLE
update gpu metric exporter daemonset

### DIFF
--- a/nvidia-pod-gpu-metrics-exporter/README.md
+++ b/nvidia-pod-gpu-metrics-exporter/README.md
@@ -173,24 +173,24 @@
 		# TYPE DCGM_FI_DEV_ROW_REMAP_FAILURE gauge
 
 
-		DCGM_FI_DEV_SM_CLOCK{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 139
-		DCGM_FI_DEV_MEM_CLOCK{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 405
-		DCGM_FI_DEV_GPU_TEMP{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 32
-		DCGM_FI_DEV_POWER_USAGE{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 5.208000
-		DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 7299606661
-		DCGM_FI_DEV_PCIE_REPLAY_COUNTER{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 0
-		DCGM_FI_DEV_GPU_UTIL{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 0
-		DCGM_FI_DEV_MEM_COPY_UTIL{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 0
-		DCGM_FI_DEV_ENC_UTIL{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 0
-		DCGM_FI_DEV_DEC_UTIL{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 0
-		DCGM_FI_DEV_XID_ERRORS{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 0
-		DCGM_FI_DEV_POWER_VIOLATION{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 0
-		DCGM_FI_DEV_THERMAL_VIOLATION{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 0
-		DCGM_FI_DEV_SYNC_BOOST_VIOLATION{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 0
-		DCGM_FI_DEV_FB_FREE{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 5059
-		DCGM_FI_DEV_FB_USED{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 0
-		DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 0
-		DCGM_FI_DEV_VGPU_LICENSE_STATUS{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0"} 0
+		DCGM_FI_DEV_SM_CLOCK{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 139
+		DCGM_FI_DEV_MEM_CLOCK{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 405
+		DCGM_FI_DEV_GPU_TEMP{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 32
+		DCGM_FI_DEV_POWER_USAGE{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 5.208000
+		DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 7324985680
+		DCGM_FI_DEV_PCIE_REPLAY_COUNTER{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 0
+		DCGM_FI_DEV_GPU_UTIL{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 0
+		DCGM_FI_DEV_MEM_COPY_UTIL{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 0
+		DCGM_FI_DEV_ENC_UTIL{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 0
+		DCGM_FI_DEV_DEC_UTIL{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 0
+		DCGM_FI_DEV_XID_ERRORS{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 0
+		DCGM_FI_DEV_POWER_VIOLATION{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 0
+		DCGM_FI_DEV_THERMAL_VIOLATION{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 0
+		DCGM_FI_DEV_SYNC_BOOST_VIOLATION{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 0
+		DCGM_FI_DEV_FB_FREE{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 5059
+		DCGM_FI_DEV_FB_USED{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 0
+		DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 0
+		DCGM_FI_DEV_VGPU_LICENSE_STATUS{gpu="0",UUID="GPU-c0b5694b-2b5d-6b20-f903-558341437f6b",device="nvidia0",container="ubuntu",namespace="default",pod="ubuntu-gpu-sunny"} 0
 		```
 
 # 삭제 가이드

--- a/nvidia-pod-gpu-metrics-exporter/manifest/pod-gpu-metrics-exporter-daemonset.yaml
+++ b/nvidia-pod-gpu-metrics-exporter/manifest/pod-gpu-metrics-exporter-daemonset.yaml
@@ -3,14 +3,19 @@ kind: DaemonSet
 metadata:
   name: pod-gpu-metrics-exporter
   namespace: monitoring
+  labels:
+    app.kubernetes.io/name: "dcgm-exporter"
+    app.kubernetes.io/version: "2.1.1"
 spec:
   selector:
     matchLabels:
-      app: pod-gpu-metrics-exporter
+      app.kubernetes.io/name: "dcgm-exporter"
+      app.kubernetes.io/version: "2.1.1"
   template:
     metadata:
       labels:
-        app: pod-gpu-metrics-exporter
+        app.kubernetes.io/name: "dcgm-exporter"
+        app.kubernetes.io/version: "2.1.1"
       name: pod-gpu-metrics-exporter
     spec:
       affinity:
@@ -24,6 +29,11 @@ spec:
                 - 'nvidia'
       containers:
       - image: nvidia/dcgm-exporter:2.1.4-2.2.0-ubuntu18.04
+        env:
+        - name: "DCGM_EXPORTER_LISTEN"
+          value: ":9400"
+        - name: "DCGM_EXPORTER_KUBERNETES"
+          value: "true"
         name: nvidia-dcgm-exporter
         ports:
         - name: gpu-metrics
@@ -33,7 +43,14 @@ spec:
           runAsUser: 0
           capabilities:
             add: ["CAP_SETFCAP", "SYS_ADMIN"]
+        volumeMounts:
+        - name: pod-gpu-resources
+          readOnly: true
+          mountPath: /var/lib/kubelet/pod-resources
       volumes:
+      - name: pod-gpu-resources
+        hostPath:
+          path: /var/lib/kubelet/pod-resources
       - name: device-metrics
         emptyDir:
           medium: Memory

--- a/nvidia-pod-gpu-metrics-exporter/manifest/pod-gpu-metrics-exporter-service.yaml
+++ b/nvidia-pod-gpu-metrics-exporter/manifest/pod-gpu-metrics-exporter-service.yaml
@@ -2,13 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    k8s-app: pod-gpu-metrics-exporter
+    app.kubernetes.io/name: "dcgm-exporter"
+    app.kubernetes.io/version: "2.1.1"
   name: pod-gpu-metrics-exporter
   namespace: monitoring
 spec:
   ports:
-  - name: metric
+  - name: metrics
     port: 9400
     targetPort: 9400
   selector:
-    app: pod-gpu-metrics-exporter
+    app.kubernetes.io/name: "dcgm-exporter"
+    app.kubernetes.io/version: "2.1.1"

--- a/nvidia-pod-gpu-metrics-exporter/manifest/pod-gpu-metrics-exporter-servicemonitor.yaml
+++ b/nvidia-pod-gpu-metrics-exporter/manifest/pod-gpu-metrics-exporter-servicemonitor.yaml
@@ -2,14 +2,16 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    k8s-app: pod-gpu-metrics-exporter
+    app.kubernetes.io/name: "dcgm-exporter"
+    app.kubernetes.io/version: "2.1.1"
   name: pod-gpu-metrics-exporter
   namespace: monitoring
 spec:
   endpoints:
   - interval: 15s
-    port: metric
+    port: metrics
     path: /metrics
   selector:
     matchLabels:
-      k8s-app: pod-gpu-metrics-exporter
+      app.kubernetes.io/name: "dcgm-exporter"
+      app.kubernetes.io/version: "2.1.1"


### PR DESCRIPTION
- add container gpu monitoring info feature option using env
- update readme monitoring example
- update daemonset, service, servicemonitor labels
- change service port name to 'metrics' from 'metric'